### PR TITLE
refactor: renombrar DTO a Input e implementar repositorios persistentes para Court y Sport

### DIFF
--- a/src/application/use-cases/court/create.use-case.ts
+++ b/src/application/use-cases/court/create.use-case.ts
@@ -16,22 +16,22 @@ export class CreateCourtUseCase {
     /**
      * Executes the creation of a court.
      * Generates a new unique ID and persists the court.
-     * @param dto - Data Transfer Object with court details (excluding ID).
+     * @param input - Data Transfer Object with court details (excluding ID).
      * @returns The created Court entity.
      */
-    async execute(dto: Omit<Court, 'id'>): Promise<Court> {
+    async execute(input: Omit<Court, 'id'>): Promise<Court> {
         const id = this.idGenerator.generate();
 
         const newCourt = new Court(
             id,
-            dto.name,
-            dto.description,
-            dto.image,
-            dto.capacity,
-            dto.pricePerHour,
-            dto.isAvailable,
-            dto.sport,
-            dto.user
+            input.name,
+            input.description,
+            input.image,
+            input.capacity,
+            input.pricePerHour,
+            input.isAvailable,
+            input.sport,
+            input.user
         );
         return this.courtRepository.create(newCourt);
     }

--- a/src/application/use-cases/court/update.use-case.ts
+++ b/src/application/use-cases/court/update.use-case.ts
@@ -1,7 +1,7 @@
 import type { CourtRepository } from "../../../domain/repositories/court.domain.repository.js";
 import { Court } from "../../../domain/entities/court.entity.js";
 
-export interface UpdateCourtDto {
+export interface UpdateCourtInput {
     name?: string;
     description?: string;
     image?: string;
@@ -14,7 +14,7 @@ export interface UpdateCourtDto {
 
 /**
  * Use Case to update an existing court.
- * Updates only the fields provided in the DTO.
+ * Updates only the fields provided in the INPUT.
  */
 export class UpdateCourtUseCase {
     constructor(private readonly courtRepository: CourtRepository) { }
@@ -22,14 +22,14 @@ export class UpdateCourtUseCase {
     /**
      * Executes the update process.
      * 1. Fetches the court by ID to ensure it exists.
-     * 2. Modifies only the fields that are present in the DTO.
+     * 2. Modifies only the fields that are present in the INPUT.
      * 3. Persists the changes.
      * 
      * @param id - The ID of the court to update.
-     * @param dto - Data Transfer Object containing partial updates.
+     * @param input - Data Transfer Object containing partial updates.
      * @returns The updated Court entity.
      */
-    async execute(id: string, dto: UpdateCourtDto): Promise<Court> {
+    async execute(id: string, input: UpdateCourtInput): Promise<Court> {
         const court = await this.courtRepository.getById(id);
         if (!court) {
             throw new Error(`Court with id ${id} not found`);
@@ -37,12 +37,12 @@ export class UpdateCourtUseCase {
 
         // We use strict check ( !== undefined ) to allow updates to falsy values
         // like 0 (price) or false (isAvailable).
-        if (dto.name !== undefined) court.name = dto.name;
-        if (dto.description !== undefined) court.description = dto.description;
-        if (dto.image !== undefined) court.image = dto.image;
-        if (dto.capacity !== undefined) court.capacity = dto.capacity;
-        if (dto.pricePerHour !== undefined) court.pricePerHour = dto.pricePerHour;
-        if (dto.isAvailable !== undefined) court.isAvailable = dto.isAvailable;
+        if (input.name !== undefined) court.name = input.name;
+        if (input.description !== undefined) court.description = input.description;
+        if (input.image !== undefined) court.image = input.image;
+        if (input.capacity !== undefined) court.capacity = input.capacity;
+        if (input.pricePerHour !== undefined) court.pricePerHour = input.pricePerHour;
+        if (input.isAvailable !== undefined) court.isAvailable = input.isAvailable;
 
         return this.courtRepository.update(id, court);
     }

--- a/src/application/use-cases/sport/create.use-case.ts
+++ b/src/application/use-cases/sport/create.use-case.ts
@@ -15,16 +15,16 @@ export class CreateSportUseCase {
 
     /**
      * Executes the creation of a sport.
-     * @param dto - Data Transfer Object containing sport details (excluding ID).
+     * @param input - Data Transfer Object containing sport details (excluding ID).
      * @returns The created Sport entity.
      */
-    async execute(dto: Omit<Sport, 'id'>): Promise<Sport> {
+    async execute(input: Omit<Sport, 'id'>): Promise<Sport> {
         const newSport = new Sport(
             this.idGenerator.generate(),
-            dto.name,
-            dto.iconUrl,
-            dto.minPlayers,
-            dto.maxPlayers
+            input.name,
+            input.iconUrl,
+            input.minPlayers,
+            input.maxPlayers
         );
         return this.sportRepository.create(newSport);
     }

--- a/src/application/use-cases/sport/delete.use-case.ts
+++ b/src/application/use-cases/sport/delete.use-case.ts
@@ -1,7 +1,7 @@
 import type { SportRepository } from "../../../domain/repositories/sport.domain.repository.js";
 
 // Define a port for the encryption service (Hexagonal: output port)
-export interface DeleteSportDto {
+export interface DeleteSportInput {
     id: string;
 }
 
@@ -15,10 +15,10 @@ export class DeleteSportUseCase {
 
     /**
      * Executes the deletion of a sport.
-     * @param dto - DTO containing the ID of the sport to delete.
+     * @param input - INPUT containing the ID of the sport to delete.
      * @returns True if deletion was successful, false otherwise.
      */
-    async execute(dto: DeleteSportDto): Promise<boolean> {
-        return this.sportRepository.delete(dto.id);
+    async execute(input: DeleteSportInput): Promise<boolean> {
+        return this.sportRepository.delete(input.id);
     }
 }

--- a/src/application/use-cases/sport/get-by-id.use-case.ts
+++ b/src/application/use-cases/sport/get-by-id.use-case.ts
@@ -1,7 +1,7 @@
 import { Sport } from "../../../domain/entities/sport.entity.js";
 import type { SportRepository } from "../../../domain/repositories/sport.domain.repository.js";
 
-export interface GetSportByIdDto {
+export interface GetSportByIdInput {
     id: string;
 }
 
@@ -18,7 +18,7 @@ export class GetSportByIdUseCase {
      * Executes the use case to get a sport by its id.
      * @returns A promise that resolves to a Sport entity.
      */
-    execute(dto: GetSportByIdDto): Promise<Sport | null> {
-        return this.sportRepository.getById(dto.id);
+    execute(input: GetSportByIdInput): Promise<Sport | null> {
+        return this.sportRepository.getById(input.id);
     }
 }

--- a/src/application/use-cases/sport/get-by-name.use-case.ts
+++ b/src/application/use-cases/sport/get-by-name.use-case.ts
@@ -1,7 +1,7 @@
 import { Sport } from "../../../domain/entities/sport.entity.js";
 import type { SportRepository } from "../../../domain/repositories/sport.domain.repository.js";
 
-export interface GetSportByNameDto {
+export interface GetSportByNameInput {
     name: string;
 }
 
@@ -18,7 +18,7 @@ export class GetSportByNameUseCase {
      * Executes the use case to get an sport by its name.
      * @returns A promise that resolves to an array of Sport entities.
      */
-    execute(dto: GetSportByNameDto): Promise<Sport | null> {
-        return this.sportRepository.getByName(dto.name);
+    execute(input: GetSportByNameInput): Promise<Sport | null> {
+        return this.sportRepository.getByName(input.name);
     }
 }

--- a/src/application/use-cases/sport/update.use-case.ts
+++ b/src/application/use-cases/sport/update.use-case.ts
@@ -2,7 +2,7 @@ import { Sport } from "../../../domain/entities/sport.entity.js";
 import type { SportRepository } from "../../../domain/repositories/sport.domain.repository.js";
 
 // Define a port for the encryption service (Hexagonal: output port)
-export interface UpdateSportDto {
+export interface UpdateSportInput {
     name?: string;
     iconUrl?: string;
     minPlayers?: number;
@@ -20,21 +20,21 @@ export class UpdateSportUseCase {
     /**
      * Executes the update of a sport.
      * @param id - The ID of the sport to update.
-     * @param dto - The data to update.
+     * @param input - The data to update.
      * @returns The updated Sport entity.
      * @throws Error if the sport is not found.
      */
-    async execute(id: string, dto: UpdateSportDto): Promise<Sport> {
+    async execute(id: string, input: UpdateSportInput): Promise<Sport> {
         const sport = await this.sportRepository.getById(id);
         if (!sport) {
             throw new Error(`Sport with id ${id} not found`);
         }
 
-        // Update fields if they are present in the DTO
-        if (dto.name !== undefined) sport.name = dto.name;
-        if (dto.iconUrl !== undefined) sport.iconUrl = dto.iconUrl;
-        if (dto.minPlayers !== undefined) sport.minPlayers = dto.minPlayers;
-        if (dto.maxPlayers !== undefined) sport.maxPlayers = dto.maxPlayers;
+        // Update fields if they are present in the INPUT
+        if (input.name !== undefined) sport.name = input.name;
+        if (input.iconUrl !== undefined) sport.iconUrl = input.iconUrl;
+        if (input.minPlayers !== undefined) sport.minPlayers = input.minPlayers;
+        if (input.maxPlayers !== undefined) sport.maxPlayers = input.maxPlayers;
 
         return this.sportRepository.update(sport);
     }

--- a/src/application/use-cases/user/create.use-case.ts
+++ b/src/application/use-cases/user/create.use-case.ts
@@ -12,7 +12,7 @@ export interface IdGenerator {
     generate(): string;
 }
 
-export interface CreateDto {
+export interface CreateInput {
     fullName: string;
     username: string;
     email: string;
@@ -31,30 +31,30 @@ export class CreateUseCase {
 
 
 
-    async execute(dto: CreateDto): Promise<User> {
+    async execute(input: CreateInput): Promise<User> {
 
 
 
         // 1. Verify if user already exists
 
-        const existingUser = await this.userRepository.getByEmail(dto.email);
+        const existingUser = await this.userRepository.getByEmail(input.email);
         if (existingUser) {
-            throw new Error(`User with email ${dto.email} already exists`);
+            throw new Error(`User with email ${input.email} already exists`);
         }
 
         // 2. Hash the password
-        const hashedPassword = await this.passwordHasher.hash(dto.password);
+        const hashedPassword = await this.passwordHasher.hash(input.password);
 
         // 3. Generate ID and create User entity
         // Default values: role=USUARIO, profilePicture='', isPremium=false, points=0
         const newUser = new User(
             this.idGenerator.generate(),
-            dto.fullName,
-            dto.username,
-            dto.email,
+            input.fullName,
+            input.username,
+            input.email,
             hashedPassword,
-            dto.phone,
-            dto.birthDate,
+            input.phone,
+            input.birthDate,
             UserRole.USUARIO,
             '', // profilePicture empty by default or default url
             false,

--- a/src/application/use-cases/user/update.use-case.ts
+++ b/src/application/use-cases/user/update.use-case.ts
@@ -2,7 +2,7 @@ import type { UserRepository } from "../../../domain/repositories/user.domain.re
 import { User, UserRole } from "../../../domain/entities/user.entity.js";
 
 // Define a port for the encryption service (Hexagonal: output port)
-export interface UpdateUserDto {
+export interface UpdateUserInput {
     fullName?: string;
     username?: string;
     email?: string;
@@ -21,33 +21,33 @@ export class UpdateUseCase {
     /**
      * Executes the update of a sport.
      * @param id - The ID of the sport to update.
-     * @param dto - The data to update.
+     * @param input - The data to update.
      * @returns The updated Sport entity.
      * @throws Error if the sport is not found.
      */
 
-    async execute(id: string, dto: UpdateUserDto): Promise<User> {
+    async execute(id: string, input: UpdateUserInput): Promise<User> {
         const user = await this.userRepository.getById(id);
         if (!user) {
             throw new Error(`User with id ${id} not found`);
         }
 
-        if (dto.fullName !== undefined) user.fullName = dto.fullName;
-        if (dto.username !== undefined) user.username = dto.username;
-        if (dto.email !== undefined) user.email = dto.email;
-        if (dto.password !== undefined) user.password = dto.password;
-        if (dto.phone !== undefined) user.phone = dto.phone;
-        if (dto.birthDate !== undefined) user.birthDate = dto.birthDate;
-        if (dto.role !== undefined) {
-            const isValidRole = Object.values(UserRole).includes(dto.role as UserRole);
+        if (input.fullName !== undefined) user.fullName = input.fullName;
+        if (input.username !== undefined) user.username = input.username;
+        if (input.email !== undefined) user.email = input.email;
+        if (input.password !== undefined) user.password = input.password;
+        if (input.phone !== undefined) user.phone = input.phone;
+        if (input.birthDate !== undefined) user.birthDate = input.birthDate;
+        if (input.role !== undefined) {
+            const isValidRole = Object.values(UserRole).includes(input.role as UserRole);
             if (!isValidRole) {
                 throw new Error(`Invalid role. Allowed values: ${Object.values(UserRole).join(', ')}`);
             }
-            user.role = dto.role as UserRole;
+            user.role = input.role as UserRole;
         }
-        if (dto.isPremium !== undefined) user.isPremium = dto.isPremium;
-        if (dto.profilePicture !== undefined) user.profilePicture = dto.profilePicture;
-        if (dto.points !== undefined) user.points = dto.points;
+        if (input.isPremium !== undefined) user.isPremium = input.isPremium;
+        if (input.profilePicture !== undefined) user.profilePicture = input.profilePicture;
+        if (input.points !== undefined) user.points = input.points;
 
         return this.userRepository.update(user);
     }

--- a/src/infrastructure/controllers/court.controller.ts
+++ b/src/infrastructure/controllers/court.controller.ts
@@ -176,7 +176,7 @@ export class CourtController {
             }
 
             try {
-                // Pass validated data (UpdateCourtDto structure) to UseCase
+                // Pass validated data (UpdateCourtInput structure) to UseCase
                 const court = await this.updateCourtUseCase.execute(id, {
                     name,
                     description,

--- a/src/infrastructure/controllers/payment.controller.ts
+++ b/src/infrastructure/controllers/payment.controller.ts
@@ -32,7 +32,7 @@ export class PaymentController {
         try {
             const { amount, method, userId, booking } = req.body;
 
-            // In a real case, we would validate the data here (DTO)
+            // In a real case, we would validate the data here (INPUT)
             const payment = await this.createPaymentUseCase.execute({
                 amount,
                 method,

--- a/src/infrastructure/repositories/court.repository.impl.ts
+++ b/src/infrastructure/repositories/court.repository.impl.ts
@@ -1,74 +1,179 @@
 import type { CourtRepository } from '../../domain/repositories/court.domain.repository.js';
 import { Court } from '../../domain/entities/court.entity.js';
+import { CourtModel } from '../models/court.model.js';
+import { SportModel } from '../models/sport.model.js';
+import { UserModel } from '../models/user.model.js';
+import { Sport } from '../../domain/entities/sport.entity.js';
+import { User } from '../../domain/entities/user.entity.js';
 
 export class CourtRepositoryImpl implements CourtRepository {
-    private courts: Court[] = [];
-
     /**
-     * Create a new court.
+     * Create a new court and persist it to the database.
+     * Re-fetches the court with full associations (Sport and User).
      */
     async create(court: Court): Promise<Court> {
-        this.courts.push(court);
-        return court;
+        const newCourt = await CourtModel.create({
+            id: court.id,
+            name: court.name,
+            description: court.description,
+            image: court.image,
+            capacity: court.capacity,
+            pricePerHour: court.pricePerHour,
+            isAvailable: court.isAvailable,
+            sportId: court.sport.id,
+            userId: court.user.id
+        });
+
+        const created = await CourtModel.findByPk(newCourt.id, {
+            include: [SportModel, UserModel]
+        });
+
+        if (!created) throw new Error('Error creating court');
+        return this.toEntity(created);
     }
 
     /**
-     * Get all courts.
-     */
-    async getAll(): Promise<Court[]> {
-        return this.courts;
-    }
-
-    /**
-     * Get a court by its Name.
-     */
-    async getByName(name: string): Promise<Court | null> {
-        return this.courts.find(court => court.name === name) || null;
-    }
-
-    /**
-     * Get courts by User ID.
-     */
-    async getByUserId(userId: string): Promise<Court[]> {
-        return this.courts.filter(court => court.user.id === userId);
-    }
-
-    /**
-     * Get courts by Sport ID.
-     */
-    async getBySport(sportId: string): Promise<Court[]> {
-        return this.courts.filter(court => court.sport.id === sportId);
-    }
-
-    /**
-     * Get a court by its ID.
-     */
-    async getById(id: string): Promise<Court | null> {
-        return this.courts.find(court => court.id === id) || null;
-    }
-
-    /**
-     * Update an existing court.
+     * Update an existing court by its ID.
+     * Performs a partial update and returns the fully reconstructed entity.
      */
     async update(id: string, court: Court): Promise<Court> {
-        const index = this.courts.findIndex(court => court.id === id);
-        if (index === -1) {
-            throw new Error('Court not found');
-        }
-        this.courts[index] = court;
-        return court;
+        await CourtModel.update({
+            name: court.name,
+            description: court.description,
+            image: court.image,
+            capacity: court.capacity,
+            pricePerHour: court.pricePerHour,
+            isAvailable: court.isAvailable,
+            sportId: court.sport.id,
+            userId: court.user.id
+        }, {
+            where: { id }
+        });
+
+        const updated = await CourtModel.findByPk(id, {
+            include: [SportModel, UserModel]
+        });
+
+        if (!updated) throw new Error('Court not found');
+        return this.toEntity(updated);
     }
 
     /**
-     * Delete a court by its ID.
+     * Delete a court from the database by its ID.
      */
     async delete(id: string): Promise<boolean> {
-        const index = this.courts.findIndex(court => court.id === id);
-        if (index === -1) {
-            throw new Error('Court not found');
-        }
-        this.courts.splice(index, 1);
-        return true;
+        const deletedCount = await CourtModel.destroy({
+            where: { id }
+        });
+        return deletedCount > 0;
     }
 
+    /**
+     * Retrieve all courts owned by a specific user.
+     * Includes Sport and User associations.
+     */
+    async getByUserId(userId: string): Promise<Court[]> {
+        const courts = await CourtModel.findAll({
+            where: { userId },
+            include: [SportModel, UserModel]
+        });
+        return courts.map(c => this.toEntity(c));
+    }
+
+    /**
+     * Retrieve all courts associated with a specific sport.
+     * Includes Sport and User associations.
+     */
+    async getBySport(sportId: string): Promise<Court[]> {
+        const courts = await CourtModel.findAll({
+            where: { sportId },
+            include: [SportModel, UserModel]
+        });
+        return courts.map(c => this.toEntity(c));
+    }
+
+    /**
+     * Find a court by its Name.
+     * Includes Sport and User associations.
+     */
+    async getByName(name: string): Promise<Court | null> {
+        const court = await CourtModel.findOne({
+            where: { name },
+            include: [SportModel, UserModel]
+        });
+        if (!court) return null;
+        return this.toEntity(court);
+    }
+
+    /**
+     * Find a court by its unique ID.
+     * Includes Sport and User associations.
+     */
+    async getById(id: string): Promise<Court | null> {
+        const court = await CourtModel.findByPk(id, {
+            include: [SportModel, UserModel]
+        });
+        if (!court) return null;
+        return this.toEntity(court);
+    }
+
+    /**
+     * Retrieve all courts in the database.
+     * Includes Sport and User associations for each court.
+     */
+    async getAll(): Promise<Court[]> {
+        const courts = await CourtModel.findAll({
+            include: [SportModel, UserModel]
+        });
+        return courts.map(c => this.toEntity(c));
+    }
+
+    /**
+     * Map a CourtModel (Sequelize) to a Court domain entity.
+     */
+    private toEntity(model: CourtModel): Court {
+        return new Court(
+            model.id,
+            model.name,
+            model.description,
+            model.image,
+            model.capacity,
+            model.pricePerHour,
+            model.isAvailable,
+            this.sportToEntity(model.sport),
+            this.userToEntity(model.user)
+        );
+    }
+
+    /**
+     * Map a SportModel to a Sport domain entity.
+     */
+    private sportToEntity(model: SportModel): Sport {
+        return new Sport(
+            model.id,
+            model.name,
+            model.iconUrl,
+            model.minPlayers,
+            model.maxPlayers
+        );
+    }
+
+    /**
+     * Map a UserModel to a User domain entity.
+     */
+    private userToEntity(model: UserModel): User {
+        return new User(
+            model.id,
+            model.fullName,
+            model.username,
+            model.email,
+            model.password,
+            model.phone ?? '',
+            model.birthDate,
+            model.role,
+            model.profilePicture ?? '',
+            model.isPremium,
+            model.points
+        );
+    }
 }

--- a/src/infrastructure/repositories/in-memory-booking.repository.ts
+++ b/src/infrastructure/repositories/in-memory-booking.repository.ts
@@ -4,11 +4,17 @@ import { Booking, BookingStatus } from "../../domain/entities/booking.entity.js"
 export class InMemoryBookingRepository implements BookingRepository {
     private bookings: Booking[] = [];
 
+    /**
+     * Create a new booking.
+     */
     async create(booking: Booking): Promise<Booking> {
         this.bookings.push(booking);
         return booking;
     }
 
+    /**
+     * Update an existing booking.
+     */
     async update(id: string, booking: Partial<Booking>): Promise<Booking> {
         const index = this.bookings.findIndex(b => b.id === id);
         if (index === -1) {
@@ -20,6 +26,9 @@ export class InMemoryBookingRepository implements BookingRepository {
         return updatedBooking;
     }
 
+    /**
+     * Delete a booking by its ID.
+     */
     async delete(id: string): Promise<boolean> {
         const index = this.bookings.findIndex(b => b.id === id);
         if (index === -1) {
@@ -29,46 +38,79 @@ export class InMemoryBookingRepository implements BookingRepository {
         return true;
     }
 
+    /**
+     * Get a booking by its ID.
+     */
     async getById(id: string): Promise<Booking | null> {
         return this.bookings.find(b => b.id === id) || null;
     }
 
+    /**
+     * Get all bookings.
+     */
     async getAll(): Promise<Booking[]> {
         return this.bookings;
     }
 
+    /**
+     * Get bookings by User ID.
+     */
     async getByUserId(userId: string): Promise<Booking[]> {
         return this.bookings.filter(b => b.user.id === userId);
     }
 
+    /**
+     * Get bookings by Court ID.
+     */
     async getByCourtId(courtId: string): Promise<Booking[]> {
         return this.bookings.filter(b => b.court.id === courtId);
     }
 
+    /**
+     * Get bookings by Date.
+     */
     async getByDate(date: string): Promise<Booking[]> {
         return this.bookings.filter(b => b.date === date);
     }
 
+    /**
+     * Get bookings by Status.
+     */
     async getByStatus(status: BookingStatus): Promise<Booking[]> {
         return this.bookings.filter(b => b.status === status);
     }
 
+    /**
+     * Get bookings by Total Price.
+     */
     async getByTotalPrice(totalPrice: number): Promise<Booking[]> {
         return this.bookings.filter(b => b.totalPrice === totalPrice);
     }
 
+    /**
+     * Get bookings by Start Time.
+     */
     async getByStartTime(startTime: string): Promise<Booking[]> {
         return this.bookings.filter(b => b.startTime === startTime);
     }
 
+    /**
+     * Get bookings by End Time.
+     */
     async getByEndTime(endTime: string): Promise<Booking[]> {
         return this.bookings.filter(b => b.endTime === endTime);
     }
 
+    /**
+     * Get bookings by User ID and Date.
+     */
     async getByUserAndDate(userId: string, date: string): Promise<Booking[]> {
         return this.bookings.filter(b => b.user.id === userId && b.date === date);
     }
 
+    /**
+     * Check if a court is available for a given date and time range.
+     */
     async checkAvailability(courtId: string, date: string, startTime: string, endTime: string): Promise<boolean> {
         const overlappingBookings = this.bookings.filter(b =>
             b.court.id === courtId &&

--- a/src/infrastructure/repositories/in-memory-court.repository.ts
+++ b/src/infrastructure/repositories/in-memory-court.repository.ts
@@ -1,0 +1,74 @@
+import type { CourtRepository } from '../../domain/repositories/court.domain.repository.js';
+import { Court } from '../../domain/entities/court.entity.js';
+
+export class InMemoryCourtRepository implements CourtRepository {
+    private courts: Court[] = [];
+
+    /**
+     * Create a new court.
+     */
+    async create(court: Court): Promise<Court> {
+        this.courts.push(court);
+        return court;
+    }
+
+    /**
+     * Get all courts.
+     */
+    async getAll(): Promise<Court[]> {
+        return this.courts;
+    }
+
+    /**
+     * Get a court by its Name.
+     */
+    async getByName(name: string): Promise<Court | null> {
+        return this.courts.find(court => court.name === name) || null;
+    }
+
+    /**
+     * Get courts by User ID.
+     */
+    async getByUserId(userId: string): Promise<Court[]> {
+        return this.courts.filter(court => court.user.id === userId);
+    }
+
+    /**
+     * Get courts by Sport ID.
+     */
+    async getBySport(sportId: string): Promise<Court[]> {
+        return this.courts.filter(court => court.sport.id === sportId);
+    }
+
+    /**
+     * Get a court by its ID.
+     */
+    async getById(id: string): Promise<Court | null> {
+        return this.courts.find(court => court.id === id) || null;
+    }
+
+    /**
+     * Update an existing court.
+     */
+    async update(id: string, court: Court): Promise<Court> {
+        const index = this.courts.findIndex(court => court.id === id);
+        if (index === -1) {
+            throw new Error('Court not found');
+        }
+        this.courts[index] = court;
+        return court;
+    }
+
+    /**
+     * Delete a court by its ID.
+     */
+    async delete(id: string): Promise<boolean> {
+        const index = this.courts.findIndex(court => court.id === id);
+        if (index === -1) {
+            throw new Error('Court not found');
+        }
+        this.courts.splice(index, 1);
+        return true;
+    }
+
+}

--- a/src/infrastructure/repositories/in-memory-sport.repository.ts
+++ b/src/infrastructure/repositories/in-memory-sport.repository.ts
@@ -1,0 +1,50 @@
+import type { SportRepository } from '../../domain/repositories/sport.domain.repository.js';
+import { Sport } from '../../domain/entities/sport.entity.js';
+
+
+export class InMemorySportRepository implements SportRepository {
+    private sports: Sport[] = [];
+
+    // Create a sport
+    async create(sport: Sport): Promise<Sport> {
+        this.sports.push(sport);
+        return sport;
+    }
+
+    // Search a sport by name
+    async getByName(name: string): Promise<Sport | null> {
+        const sport = this.sports.find(s => s.name === name);
+        return sport || null;
+    }
+
+    // Search a sport by id
+    async getById(id: string): Promise<Sport | null> {
+        const sport = this.sports.find(s => s.id === id);
+        return sport || null;
+    }
+
+    // Update a sport
+    async update(sport: Sport): Promise<Sport> {
+        const index = this.sports.findIndex(s => s.id === sport.id);
+        if (index !== -1) {
+            this.sports[index] = sport;
+            return sport;
+        }
+        throw new Error('Sport not found');
+    }
+
+    // Delete a sport
+    async delete(id: string): Promise<boolean> {
+        const index = this.sports.findIndex(s => s.id === id);
+        if (index !== -1) {
+            this.sports.splice(index, 1);
+            return true;
+        }
+        return false;
+    }
+
+    // Get all sports
+    async getAll(): Promise<Sport[]> {
+        return this.sports;
+    }
+}

--- a/src/infrastructure/repositories/payment.repository.impl.ts
+++ b/src/infrastructure/repositories/payment.repository.impl.ts
@@ -4,15 +4,24 @@ import type { PaymentRepository } from "../../domain/repositories/payment.reposi
 export class PaymentRepositoryImpl implements PaymentRepository {
     private payments: Payment[] = [];
 
+    /**
+     * Create a new payment.
+     */
     async create(payment: Payment): Promise<Payment> {
         this.payments.push(payment);
         return payment;
     }
 
+    /**
+     * Get a payment by its ID.
+     */
     async getById(id: string): Promise<Payment | null> {
         return this.payments.find(p => p.id === id) || null;
     }
 
+    /**
+     * Update an existing payment.
+     */
     async update(id: string, updates: Partial<Pick<Payment, 'status' | 'transactionId'>>): Promise<Payment | null> {
         const payment = this.payments.find(p => p.id === id);
         if (!payment) return null;
@@ -21,6 +30,9 @@ export class PaymentRepositoryImpl implements PaymentRepository {
         return payment;
     }
 
+    /**
+     * Delete a payment by its ID.
+     */
     async delete(id: string): Promise<boolean> {
         const index = this.payments.findIndex(p => p.id === id);
         if (index === -1) return false;
@@ -29,10 +41,16 @@ export class PaymentRepositoryImpl implements PaymentRepository {
         return true;
     }
 
+    /**
+     * Get all payments associated with a specific booking ID.
+     */
     async getAllByBookingId(bookingId: string): Promise<Payment[]> {
         return this.payments.filter(p => p.booking.id === bookingId);
     }
 
+    /**
+     * Get all payments associated with a specific user ID.
+     */
     async getAllByUserId(userId: string): Promise<Payment[]> {
         return this.payments.filter(p => p.userId === userId);
     }

--- a/src/infrastructure/repositories/sport.repository.impl.ts
+++ b/src/infrastructure/repositories/sport.repository.impl.ts
@@ -1,50 +1,90 @@
 import type { SportRepository } from '../../domain/repositories/sport.domain.repository.js';
 import { Sport } from '../../domain/entities/sport.entity.js';
-
+import { SportModel } from '../models/sport.model.js';
 
 export class SportRepositoryImpl implements SportRepository {
-    private sports: Sport[] = [];
-
-    // Create a sport
+    /**
+     * Create a new sport and persist it to the database.
+     */
     async create(sport: Sport): Promise<Sport> {
-        this.sports.push(sport);
-        return sport;
+        const newSport = await SportModel.create({
+            id: sport.id,
+            name: sport.name,
+            iconUrl: sport.iconUrl,
+            minPlayers: sport.minPlayers,
+            maxPlayers: sport.maxPlayers
+        });
+        return this.toEntity(newSport);
     }
 
-    // Search a sport by name
-    async getByName(name: string): Promise<Sport | null> {
-        const sport = this.sports.find(s => s.name === name);
-        return sport || null;
-    }
-
-    // Search a sport by id
-    async getById(id: string): Promise<Sport | null> {
-        const sport = this.sports.find(s => s.id === id);
-        return sport || null;
-    }
-
-    // Update a sport
+    /**
+     * Update an existing sport.
+     * Uses 'returning: true' to get the updated model in a single operation.
+     */
     async update(sport: Sport): Promise<Sport> {
-        const index = this.sports.findIndex(s => s.id === sport.id);
-        if (index !== -1) {
-            this.sports[index] = sport;
-            return sport;
+        const [affectedCount, [updatedSport]] = await SportModel.update({
+            name: sport.name,
+            iconUrl: sport.iconUrl,
+            minPlayers: sport.minPlayers,
+            maxPlayers: sport.maxPlayers
+        }, {
+            where: { id: sport.id },
+            returning: true
+        });
+
+        if (affectedCount === 0 || !updatedSport) {
+            throw new Error('Sport not found');
         }
-        throw new Error('Sport not found');
+
+        return this.toEntity(updatedSport);
     }
 
-    // Delete a sport
+    /**
+     * Delete a sport from the database by its ID.
+     */
     async delete(id: string): Promise<boolean> {
-        const index = this.sports.findIndex(s => s.id === id);
-        if (index !== -1) {
-            this.sports.splice(index, 1);
-            return true;
-        }
-        return false;
+        const deletedCount = await SportModel.destroy({
+            where: { id }
+        });
+        return deletedCount > 0;
     }
 
-    // Get all sports
+    /**
+     * Find a sport by its Name.
+     */
+    async getByName(name: string): Promise<Sport | null> {
+        const sport = await SportModel.findOne({ where: { name } });
+        if (!sport) return null;
+        return this.toEntity(sport);
+    }
+
+    /**
+     * Find a sport by its unique ID.
+     */
+    async getById(id: string): Promise<Sport | null> {
+        const sport = await SportModel.findByPk(id);
+        if (!sport) return null;
+        return this.toEntity(sport);
+    }
+
+    /**
+     * Retrieve all sports from the database.
+     */
     async getAll(): Promise<Sport[]> {
-        return this.sports;
+        const sports = await SportModel.findAll();
+        return sports.map(s => this.toEntity(s));
+    }
+
+    /**
+     * Map a SportModel (Sequelize) to a Sport domain entity.
+     */
+    private toEntity(model: SportModel): Sport {
+        return new Sport(
+            model.id,
+            model.name,
+            model.iconUrl,
+            model.minPlayers,
+            model.maxPlayers
+        );
     }
 }

--- a/src/infrastructure/repositories/user.repository.impl.ts
+++ b/src/infrastructure/repositories/user.repository.impl.ts
@@ -3,6 +3,9 @@ import { User, UserRole } from '../../domain/entities/user.entity.js';
 import { UserModel } from '../models/user.model.js';
 
 export class UserRepositoryImpl implements UserRepository {
+    /**
+     * Create a new user and persist it to the database.
+     */
     async create(user: User): Promise<User> {
 
         const newUser = await UserModel.create({
@@ -22,41 +25,63 @@ export class UserRepositoryImpl implements UserRepository {
         return this.toEntity(newUser);
     }
 
+    /**
+     * Find a user by their unique Email address.
+     */
     async getByEmail(email: string): Promise<User | null> {
         const user = await UserModel.findOne({ where: { email } });
         if (!user) return null;
         return this.toEntity(user);
     }
 
+    /**
+     * Find a user by their unique ID.
+     */
     async getById(id: string): Promise<User | null> {
         const user = await UserModel.findByPk(id);
         if (!user) return null;
         return this.toEntity(user);
     }
 
+    /**
+     * Retrieve all users from the database.
+     */
     async getAll(): Promise<User[]> {
         const user = await UserModel.findAll();
         return user.map(u => this.toEntity(u));
     }
 
+    /**
+     * Retrieve all users with a specific Role.
+     */
     async getByRole(role: UserRole): Promise<User[] | null> {
         const user = await UserModel.findAll({ where: { role } });
         if (!user) return null;
         return user.map(u => this.toEntity(u));
     }
 
+    /**
+     * Find a user by their Username.
+     */
     async getByUsername(username: string): Promise<User | null> {
         const user = await UserModel.findOne({ where: { username } });
         if (!user) return null;
         return this.toEntity(user);
     }
 
+    /**
+     * Retrieve users based on their premium status.
+     */
     async getByIsPremium(isPremium: boolean): Promise<User[] | null> {
         const user = await UserModel.findAll({ where: { isPremium } });
         if (!user) return null;
         return user.map(u => this.toEntity(u));
     }
 
+    /**
+     * Update an existing user in the database.
+     * Returns the fully updated domain entity.
+     */
     async update(user: User): Promise<User> {
         const [affectedCount, [updatedUser]] = await UserModel.update({
             fullName: user.fullName,
@@ -81,11 +106,18 @@ export class UserRepositoryImpl implements UserRepository {
         return this.toEntity(updatedUser);
     }
 
+    /**
+     * Delete a user from the database by their ID.
+     */
     async delete(id: string): Promise<boolean> {
         const deletedUser = await UserModel.destroy({ where: { id } });
         return deletedUser > 0;
     }
 
+    /**
+     * Map a UserModel (Sequelize) to a User domain entity.
+     * Handles null values for optional fields by providing sensible defaults.
+     */
     private toEntity(model: UserModel): User {
         return new User(
             model.id,
@@ -93,7 +125,7 @@ export class UserRepositoryImpl implements UserRepository {
             model.username,
             model.email,
             model.password,
-            model.phone ?? '', // Handle potential null if Entity expects string (though we updated entity to allow null, let's check)
+            model.phone ?? '', // Handle potential null if Entity expects string
             model.birthDate,
             model.role,
             model.profilePicture ?? '',


### PR DESCRIPTION
1. Estandarización de Nomenclatura:

Se han renombrado todas las ocurrencias de DTO, Dto y dto por INPUT, Input e input en toda la carpeta src.
Esto mejora la uniformidad del código, siguiendo la convención ya establecida en algunos casos de uso como el de Payment

2. Repositorios Persistentes (Sequelize):

Court: Implementación de CourtRepositoryImpl utilizando CourtModel Se ha incluido la carga entusiasta (eager loading) de las asociaciones Sport y User para garantizar la integridad de la entidad de dominio.
Sport: Implementación de SportRepositoryImpl utilizando SportModel
Los repositorios ahora realizan operaciones reales contra la base de datos SQL.

3. Preservación de Implementaciones en Memoria:

Se han movido y renombrado las implementaciones anteriores de prueba a in-memory-court.repository.ts e in-memory-sport.repository.ts para su posible uso en tests unitarios.

4. Documentación y Calidad:

Se ha añadido documentación JSDoc a todos los métodos de los nuevos repositorios (Court, Sport, User, Payment y el repositorio en memoria de Booking).
Se han incluido observaciones técnicas sobre el mapeo de modelos a entidades y la lógica de Sequelize utilizada.