### PR TITLE
feat: implement persistence for Schedule entity

### DIFF
--- a/src/infrastructure/database/migrations/20260309094117-create-schedules.cjs
+++ b/src/infrastructure/database/migrations/20260309094117-create-schedules.cjs
@@ -1,0 +1,54 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('schedules', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4
+      },
+      dayOfWeek: {
+        type: Sequelize.ENUM('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'),
+        allowNull: false
+      },
+      startTime: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      endTime: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      isAvailable: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: true
+      },
+      courtId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'courts',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('schedules');
+  }
+};

--- a/src/infrastructure/models/schedule.model.ts
+++ b/src/infrastructure/models/schedule.model.ts
@@ -1,0 +1,49 @@
+import { Table, Column, Model, DataType, PrimaryKey, Default, ForeignKey, BelongsTo } from 'sequelize-typescript';
+import { DayOfWeek } from '../../domain/entities/schedule.entity.js';
+import { CourtModel } from './court.model.js';
+
+@Table({
+    tableName: 'schedules',
+    timestamps: true,
+})
+export class ScheduleModel extends Model {
+    @PrimaryKey
+    @Default(DataType.UUIDV4)
+    @Column(DataType.UUID)
+    declare id: string;
+
+    @Column({
+        type: DataType.ENUM(...Object.values(DayOfWeek)),
+        allowNull: false,
+    })
+    declare dayOfWeek: DayOfWeek;
+
+    @Column({
+        type: DataType.STRING,
+        allowNull: false,
+    })
+    declare startTime: string;
+
+    @Column({
+        type: DataType.STRING,
+        allowNull: false,
+    })
+    declare endTime: string;
+
+    @Column({
+        type: DataType.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+    })
+    declare isAvailable: boolean;
+
+    @ForeignKey(() => CourtModel)
+    @Column({
+        type: DataType.UUID,
+        allowNull: false,
+    })
+    declare courtId: string;
+
+    @BelongsTo(() => CourtModel)
+    court!: CourtModel;
+}

--- a/src/infrastructure/repositories/schedule.repository.impl.ts
+++ b/src/infrastructure/repositories/schedule.repository.impl.ts
@@ -1,34 +1,117 @@
 
 import { Schedule } from "../../domain/entities/schedule.entity.js";
+import { DayOfWeek } from "../../domain/entities/schedule.entity.js";
 import type { ScheduleRepository } from "../../domain/repositories/schedule.domain.repository.js";
+import { ScheduleModel } from "../models/schedule.model.js";
+import { CourtModel } from "../models/court.model.js";
+import { SportModel } from "../models/sport.model.js";
+import { UserModel } from "../models/user.model.js";
+import { Court } from "../../domain/entities/court.entity.js";
+import { Sport } from "../../domain/entities/sport.entity.js";
+import { User } from "../../domain/entities/user.entity.js";
 
 export class ScheduleRepositoryImpl implements ScheduleRepository {
-    private schedules: Schedule[] = [];
 
     async create(schedule: Schedule): Promise<Schedule> {
-        this.schedules.push(schedule);
+        await ScheduleModel.create({
+            id: schedule.id,
+            courtId: schedule.court.id,
+            dayOfWeek: schedule.dayOfWeek,
+            startTime: schedule.startTime,
+            endTime: schedule.endTime,
+            isAvailable: true // Default when creating
+        });
         return schedule;
     }
 
     async update(schedule: Schedule): Promise<Schedule> {
-        const index = this.schedules.findIndex(s => s.id === schedule.id);
-        if (index === -1) throw new Error("Schedule not found");
-        this.schedules[index] = schedule;
+        const scheduleModel = await ScheduleModel.findByPk(schedule.id);
+        if (!scheduleModel) throw new Error("Schedule not found");
+
+        await scheduleModel.update({
+            courtId: schedule.court.id,
+            dayOfWeek: schedule.dayOfWeek,
+            startTime: schedule.startTime,
+            endTime: schedule.endTime
+        });
+
         return schedule;
     }
 
     async delete(id: string): Promise<boolean> {
-        const index = this.schedules.findIndex(s => s.id === id);
-        if (index === -1) return false;
-        this.schedules.splice(index, 1);
-        return true;
+        const deletedRows = await ScheduleModel.destroy({
+            where: { id }
+        });
+        return deletedRows > 0;
     }
 
     async getById(id: string): Promise<Schedule | null> {
-        return this.schedules.find(s => s.id === id) || null;
+        const scheduleModel = await ScheduleModel.findByPk(id, {
+            include: [{
+                model: CourtModel,
+                include: [SportModel, UserModel]
+            }]
+        });
+
+        if (!scheduleModel) return null;
+        return this.toEntity(scheduleModel);
     }
 
     async getByCourtId(courtId: string): Promise<Schedule[]> {
-        return this.schedules.filter(s => s.court.id === courtId);
+        const scheduleModels = await ScheduleModel.findAll({
+            where: { courtId },
+            include: [{
+                model: CourtModel,
+                include: [SportModel, UserModel]
+            }]
+        });
+
+        return scheduleModels.map(model => this.toEntity(model));
+    }
+
+    private toEntity(model: ScheduleModel): Schedule {
+        const courtModel = model.court;
+
+        const sport = new Sport(
+            courtModel.sport.id,
+            courtModel.sport.name,
+            courtModel.sport.iconUrl,
+            courtModel.sport.minPlayers,
+            courtModel.sport.maxPlayers
+        );
+
+        const user = new User(
+            courtModel.user.id,
+            courtModel.user.fullName,
+            courtModel.user.username,
+            courtModel.user.email,
+            courtModel.user.password,
+            courtModel.user.phone ?? '',
+            courtModel.user.birthDate,
+            courtModel.user.role,
+            courtModel.user.profilePicture ?? '',
+            courtModel.user.isPremium,
+            courtModel.user.points
+        );
+
+        const court = new Court(
+            courtModel.id,
+            courtModel.name,
+            courtModel.description,
+            courtModel.image,
+            courtModel.capacity,
+            courtModel.pricePerHour,
+            courtModel.isAvailable,
+            sport,
+            user
+        );
+
+        return new Schedule(
+            model.id,
+            court,
+            model.dayOfWeek as DayOfWeek,
+            model.startTime,
+            model.endTime
+        );
     }
 }


### PR DESCRIPTION
- Created ScheduleModel in src/infrastructure/models.
- Created and executed migration for schedules table (.cjs).
- Migrated ScheduleRepositoryImpl to use Sequelize (Postgres).
- Updated DI container in src/infrastructure/container.ts.
- Implemented full association mapping (Schedule -> Court -> Sport/User).