### PR TITLE
refactor(booking): remove PENDING status and set default to CONFIRMED

### DIFF
--- a/src/application/use-cases/booking/create.use-case.ts
+++ b/src/application/use-cases/booking/create.use-case.ts
@@ -60,7 +60,7 @@ export class CreateBookingUseCase {
             input.endTime,
             input.numPeople,
             input.totalPrice,
-            BookingStatus.PENDING,
+            BookingStatus.CONFIRMED,
             null, // Initial payment is null
             now,
             now

--- a/src/domain/entities/booking.entity.ts
+++ b/src/domain/entities/booking.entity.ts
@@ -4,7 +4,6 @@ import type { Court } from "./court.entity.js";
 import type { Payment } from "./payment.entity.js";
 
 export enum BookingStatus {
-    PENDING = 'pending',
     CONFIRMED = 'confirmed',
     CANCELLED = 'cancelled',
     COMPLETED = 'completed'

--- a/src/infrastructure/database/migrations/20260323101000-remove-pending-from-booking-status.cjs
+++ b/src/infrastructure/database/migrations/20260323101000-remove-pending-from-booking-status.cjs
@@ -1,0 +1,30 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // 1. Update any existing 'pending' bookings to 'confirmed'
+    await queryInterface.bulkUpdate('bookings', 
+      { status: 'confirmed' }, 
+      { status: 'pending' }
+    );
+
+    // 2. Change the default value of the 'status' column to 'confirmed'
+    // Note: We keep 'pending' in the ENUM type for now to avoid complex migrations,
+    // but the code will no longer use it or allow it.
+    await queryInterface.changeColumn('bookings', 'status', {
+      type: Sequelize.ENUM('pending', 'confirmed', 'cancelled', 'completed'),
+      allowNull: false,
+      defaultValue: 'confirmed'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Revert the default value to 'pending'
+    await queryInterface.changeColumn('bookings', 'status', {
+      type: Sequelize.ENUM('pending', 'confirmed', 'cancelled', 'completed'),
+      allowNull: false,
+      defaultValue: 'pending'
+    });
+  }
+};

--- a/src/infrastructure/models/booking.model.ts
+++ b/src/infrastructure/models/booking.model.ts
@@ -75,7 +75,7 @@ export class BookingModel extends Model {
     @Column({
         type: DataType.ENUM(...Object.values(BookingStatus)),
         allowNull: false,
-        defaultValue: BookingStatus.PENDING,
+        defaultValue: BookingStatus.CONFIRMED,
     })
     declare status: BookingStatus;
 }

--- a/src/infrastructure/repositories/booking.repository.impl.ts
+++ b/src/infrastructure/repositories/booking.repository.impl.ts
@@ -361,6 +361,7 @@ export class BookingRepositoryImpl implements BookingRepository {
             model.image,
             model.capacity,
             model.pricePerHour,
+            model.location,
             model.isAvailable,
             this.sportToEntity(model.sport),
             this.userToEntity(model.user) // The owner of the court

--- a/src/infrastructure/repositories/payment.repository.impl.ts
+++ b/src/infrastructure/repositories/payment.repository.impl.ts
@@ -244,6 +244,7 @@ export class PaymentRepositoryImpl implements PaymentRepository {
             bookingModel.court.image,
             bookingModel.court.capacity,
             bookingModel.court.pricePerHour,
+            bookingModel.court.location,
             bookingModel.court.isAvailable,
             sport,
             owner

--- a/src/infrastructure/repositories/schedule.repository.impl.ts
+++ b/src/infrastructure/repositories/schedule.repository.impl.ts
@@ -158,6 +158,7 @@ export class ScheduleRepositoryImpl implements ScheduleRepository {
             courtModel.image,
             courtModel.capacity,
             courtModel.pricePerHour,
+            courtModel.location,
             courtModel.isAvailable,
             sport,
             owner


### PR DESCRIPTION
- Removed PENDING from BookingStatus enum
- Updated Booking creation use case and model to default to CONFIRMED
- Created migration to update database defaults and existing records
- Fixed Court entity constructor calls across repositories